### PR TITLE
Some style improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,18 +29,22 @@
     <div class="viewer">
         <div class="info">
             <h3 style="text-align:center;">Turn: #<span id="turn"></span></h3>
-            <div id="infoRed" class="info">
-                <h3 style="text-align:center; color:#F00">Red</h3>
-                <p class="property">Karbonite: <span id="red_karbonite"></span></p>
-            </div>
-            <div id="infoBlue" class="info">
-                <h3 style="text-align:center; color:#00F">Blue</h3>
-                <p class="property">Karbonite: <span id="blue_karbonite"></span></p>
-            </div>
+            <table>
+                <tr><td>Karbonite</td><td class="infoRed" id="red_karbonite"></td><td class="infoBlue" id="blue_karbonite"></td></tr>
+                <tr><td>Workers</td><td class="infoRed" id="infoRedWorker"></td><td class="infoBlue" id="infoBlueWorker"></td></tr>
+                <tr><td>Knights</td><td class="infoRed" id="infoRedKnight"></td><td class="infoBlue" id="infoBlueKnight"></td></tr>
+                <tr><td>Rangers</td><td class="infoRed" id="infoRedRanger"></td><td class="infoBlue" id="infoBlueRanger"></td></tr>
+                <tr><td>Mages</td><td class="infoRed" id="infoRedMage"></td><td class="infoBlue" id="infoBlueMage"> </td></tr>
+                <tr><td>Healers</td><td class="infoRed" id="infoRedHealer"></td><td class="infoBlue" id="infoBlueHealer"></td></tr>
+                <tr><td>Factories</td><td class="infoRed" id="infoRedFactory"></td><td class="infoBlue" id="infoBlueFactory"></td></tr>
+            </table>
         </div>
         <div class="maps">
             <canvas id="earth" width=500 height=500 style="border: 1px solid #000"></canvas>
             <canvas id="mars" width=500 height=500 style="border: 1px solid #000"></canvas>
+        </div>
+        <div class="graphs">
+            <canvas id="graphs" width=1006 height=200 style="border: 1px solid #000"></canvas>
         </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@
 var UNIT_CLASSES = ['Worker', 'Knight', 'Ranger', 'Mage', 'Healer', 'Factory'];
 var MAX_HEALTHS = {'Worker': 100, 'Knight': 250, 'Ranger': 200, 'Mage': 80, 'Healer': 100, 'Factory': 300};
 var TEAMS = ['Red', 'Blue'];
-var TEAM_COLOR = {'Red': '#F00', 'Blue': '#00F'};
+var TEAM_COLOR = {'Red': '#ac1c1e', 'Blue': '#3273dc'};
 var ATTACK_COLOR = {'Red': 'rgba(255, 0, 0, 0.7)', 'Blue': 'rgba(0, 0, 255, 0.7)'};
 var HEAL_COLOR = {'Red': 'rgba(77, 175, 74, 0.8)', 'Blue': 'rgba(77, 175, 74, 0.8)'};
 var HEAD_SIZE = 0.3;
@@ -245,6 +245,9 @@ function visualize(data) {
     // Now, to render an animation frame:
     function render_planet(t, fractional_t, planet, ctx, canvas, unit_count) {
         ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+        // ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
         let karbonite_at_tick = karbonite_maps[planet][t];
 
         // Draw the map
@@ -254,16 +257,42 @@ function visualize(data) {
                 var px = j, py = flipY(i);
 
                 // Black out impassable squares
-                if (!planet_maps[planet][i][j]) {
-                    ctx.fillStyle = '#000'
-                        ctx.fillRect(px * (500 / w), py * (500 / h),
-                                500 / w, 500 / h);
-                }
+                ctx.beginPath();
+                ctx.rect(px * (500 / w), py * (500 / h), 500 / w, 500 / h);
 
-                // Write amount of Karbonite at location
-                ctx.fillStyle = '#888';
-                ctx.fillText(karbonite_at_tick[i][j].toString(),
-                        (px + 0.4) * (500 / w), (py + 0.6) * 500 / h);
+                if (!planet_maps[planet][i][j]) {
+                    if (planet == 'Mars') {
+                        ctx.fillStyle = '#5d1e10';
+                        ctx.strokeStyle = '#591d0f';
+                    } else {
+                        ctx.fillStyle = '#306796';
+                        ctx.strokeStyle = '#2e6491';
+                    }
+
+                } else {
+                    if (planet == 'Mars') {
+                        ctx.fillStyle = "#e4cdc0";
+                        ctx.strokeStyle = '#c4b0a5';
+                    } else {
+                        ctx.fillStyle = "#FFF";
+                        ctx.strokeStyle = '#e4e4e4';
+                    }
+                }
+                
+                ctx.fill();
+                ctx.lineWidth = 1;
+                ctx.stroke();
+
+                if (karbonite_at_tick[i][j] > 0) {
+                    // Write amount of Karbonite at location
+                    ctx.globalAlpha = (karbonite_at_tick[i][j] > 0 ? 0.2 : 0.0) + 0.6 * (karbonite_at_tick[i][j] / 50);
+                    ctx.fillStyle = '#337';
+                    ctx.fill();
+                    ctx.globalAlpha = 1.0;
+                    // ctx.fillStyle = '#888';
+                    // ctx.fillText(karbonite_at_tick[i][j].toString(),
+                    //         (px + 0.4) * (500 / w), (py + 0.6) * 500 / h);
+                }
             }
         }
 
@@ -291,6 +320,7 @@ function visualize(data) {
 
         for (var i = 0; i < data[t].units.length; i += 1) {
             var unit = data[t].units[i];
+
             var prevUnit = prevUnits[unit.id];
             if (prevUnit === undefined) prevUnit = unit;
 
@@ -330,7 +360,10 @@ function visualize(data) {
                         unitTypeStyle = '#808'; break;
                     case "Factory":
                         // Factories will be gray
-                        unitTypeStyle = '#888'; break;
+                        unitTypeStyle = '#000'; break;
+                    case "Rocket":
+                        // Rockets
+                        unitTypeStyle = '#000'; break;
                     default:
                         // Unimplemented unit type
                         unitTypeStyle = '#FFF';
@@ -352,7 +385,7 @@ function visualize(data) {
                     health = prevUnit.health / MAX_HEALTHS[unit.unit_type];
                 }
 
-                if (unit.unit_type == "Factory" || unit.unit_type == "Rocket") {
+                if (unit.unit_type == "Factory") {
                     // Fill the border
                     ctx.fillStyle = unitTypeStyle;
                     ctx.fillRect(
@@ -380,10 +413,11 @@ function visualize(data) {
                     var cy = (py + 0.5) * 500 / h;
                     var radius = 0.3 * 500 / w;
 
+                    let lineWidthMultiplier = 20 / w;
                     ctx.beginPath();
                     ctx.arc(cx, cy, radius, 0, 2 * Math.PI);
                     ctx.strokeStyle = TEAM_COLOR[id2team[unit.id]];
-                    ctx.lineWidth = 6;
+                    ctx.lineWidth = 6 * lineWidthMultiplier;
                     ctx.stroke();
 
                     if (health < 1) {
@@ -403,6 +437,13 @@ function visualize(data) {
                     // Radial health
                     // ctx.arc(cx, cy, health * radius, 0, 2 * Math.PI);
                     ctx.fill();
+
+                    if (unit.unit_type == "Rocket") {
+                        // Draw how many units are inside
+                        // ctx.fillStyle = '#888';
+                        // ctx.fillText(karbonite_at_tick[i][j].toString(),
+                        //         (px + 0.4) * (500 / w), (py + 0.6) * 500 / h);
+                    }
                 }
 
                 ctx.globalAlpha = 1;

--- a/styles.css
+++ b/styles.css
@@ -31,25 +31,54 @@ input {
 }
 
 .viewer {
-    float: center;
+    margin-left: auto;
+    margin-right: auto;
+    width: 1350px;
 }
 
 .maps {
     display: inline-block;
-    float: left;
+    float: right;
+}
+
+.graphs {
+    float: right;
 }
 
 .info {
     display: inline-block;
     font-weight: bold;
-    min-width: 110px;
+    width: 300px;
     float: left;
     padding: 10px;
     text-align: left;
 }
 
+.info table {
+    background: #333;
+    border: 1px solid #333;
+    border-radius: 5px;
+    color: #FFF;
+    width: 100%;
+    border-spacing: 0px;
+}
+
+.info table tr {
+    height: 30px;
+}
+
 .property {
     text-align: left;
+}
+
+.infoRed {
+    background: #e41a1c;
+    width: 50px;
+}
+
+.infoBlue {
+    background: #377eb8;
+    width: 50px;
 }
 
 /* make table a bit more readable */


### PR DESCRIPTION
Note that the color scheme change for the maps may have caused some performance issues due to drawing a rectangle for every single tile. Might have to do the drawing in a smarter way in the future.

The leftmost graph shows the karbonite for each player over time, and the middle graph shows the total unit value over time. The rightmost graph isn't used at the moment. Not sure what to put there.

Also changed unit health from being displayed using a smaller/larger circle. Now it is using a fill from bottom to top instead as it is easier to judge relative values that way.

![image](https://user-images.githubusercontent.com/1144597/34910825-5623eeca-f8bd-11e7-9304-e03436f24293.png)
